### PR TITLE
adds sample .env for documentation

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,5 @@
+MAIL_RECEIVING_ACCOUNT=<receiving-account@sample.com>
+SMTP_HOST=<receiving-host>
+SMTP_PORT=<SMTP port>
+SMTP_AUTH_USER=<mailing account@sample.com>
+SMTP_AUTH_PASS=<mail account password>


### PR DESCRIPTION
I added a .env-sample to the root of the project so that future maintainers know what env variables are needed to get the project up and running. The contents of the file are:

```
MAIL_RECEIVING_ACCOUNT=<receiving-account@sample.com>
SMTP_HOST=<receiving-host>
SMTP_PORT=<SMTP port>
SMTP_AUTH_USER=<mailing account@sample.com>
SMTP_AUTH_PASS=<mail account password>

```

